### PR TITLE
feat(proxy): add keep-alive functionality and optimize proxy test method

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,7 +19,7 @@ jobs:
       - run: npm ci
       - run: npm run build
       - name: Upload Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: extension
           path: public/extension.zip

--- a/src/background.js
+++ b/src/background.js
@@ -3,10 +3,10 @@ const browser = window.browser || window.chrome
 const DEFAULT_PROXY_CONFIG = {
 	type: 'socks',
 	proxyDNS: true,
-	host: 'cr-unblocker.us.to',
-	port: 1080,
-	username: 'crunblocker',
-	password: 'crunblocker',
+	host: 'us.community-proxy.meganeko.dev',
+	port: 5445,
+	username: 'GeoBypassCommunity-US',
+	password: 'UseWithRespect',
 	failoverTimeout: 3
 }
 

--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -21,6 +21,9 @@
             <label for="switchRegion">Switch region on Crunchyroll</label>
 
             <h2>Proxy Configuration</h2>
+            <input type="checkbox" id="keepAlive" class="cr-checkbox"/>
+            <label for="keepAlive" title="Keeps the proxy connection active. Some providers terminate idle connections, so this prevents that.">Keep Alive</label>
+            <br>
             <input type="checkbox" id="proxyCustom" class="cr-checkbox"/>
             <label for="proxyCustom">Use custom proxy</label>
 

--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -22,7 +22,9 @@
 
             <h2>Proxy Configuration</h2>
             <input type="checkbox" id="keepAlive" class="cr-checkbox"/>
-            <label for="keepAlive" title="Keeps the proxy connection active. Some providers terminate idle connections, so this prevents that.">Keep Alive</label>
+            <label for="keepAlive"
+                   title="Keeps the proxy connection active. Some providers terminate idle connections, so this prevents that.">Keep
+                Alive</label>
             <br>
             <input type="checkbox" id="proxyCustom" class="cr-checkbox"/>
             <label for="proxyCustom">Use custom proxy</label>
@@ -81,10 +83,32 @@
         <div class="tab" id="tab-about">
             <h2>About</h2>
             <ul>
-                <li><a target="_blank" href="https://cr-unblocker.us.to/">Changelog</a></li>
-                <li><a target="_blank" href="https://github.com/fhuhne/CR-Unblocker">Source code</a></li>
+                <li><a href="https://cr-unblocker.us.to/" target="_blank">Changelog</a> – See what's new!</li>
+                <li><a href="https://github.com/fhuhne/CR-Unblocker" target="_blank" rel="noopener">Source code</a> –
+                    Check out how it works or contribute!
+                </li>
+                <li>
+                    <b>Looking for something more flexible?</b><br>
+                    Try my other extension,
+                    <a href="https://github.com/MeGaNeKoS/GeoBypasser" target="_blank" rel="noopener"><b>GeoBypasser</b></a>!
+                    <br>
+                    It’s designed to be much more generic, letting you set up custom rules per website. That means you
+                    can easily access not just Crunchyroll, but also BiliBili and pretty much any other
+                    region-restricted site—without the hassle. Same simple idea, just way broader support!
+                </li>
+                <li>
+                    <b>Support CR-Unblocker!</b><br>
+                    If you find this extension useful, please consider
+                    <a href="https://ko-fi.com/meganeko__" target="_blank" rel="noopener">buying me a coffee on
+                        Ko-fi</a> or
+                    <a href="https://www.patreon.com/c/__meganeko__" target="_blank" rel="noopener">supporting on
+                        Patreon</a>.
+                    <br>
+                    Every bit helps keep the free proxy running for everyone. Thank you! ❤️
+                </li>
             </ul>
         </div>
+
     </div>
 </div>
 <script type="text/javascript" src="dashboard.js"></script>

--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -59,6 +59,7 @@ function addSettingInput(id, callback) {
  * Save states
  */
 addSettingCheckbox('switchRegion')
+addSettingCheckbox('keepAlive')
 addSettingCheckbox('proxyCustom')
 addSettingInput('proxyType')
 addSettingInput('proxyHost')
@@ -72,6 +73,7 @@ addSettingInput('proxyPass')
  */
 function displaySettings(settings) {
 	document.getElementById('switchRegion').checked = settings.switchRegion
+	document.getElementById('keepAlive').checked = settings.keepAlive
 	document.getElementById('proxyCustom').checked = settings.proxyCustom
 	document.getElementById('proxyType').value = settings.proxyType || 'socks'
 	document.getElementById('proxyHost').value = settings.proxyHost

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -20,7 +20,8 @@
     "*://*.cr-unblocker.us.to/*",
     "webRequest",
     "webRequestBlocking",
-    "proxy"
+    "proxy",
+    "tabs"
   ],
 
   "browser_action": {

--- a/src/settings.js
+++ b/src/settings.js
@@ -8,6 +8,7 @@ var browser = browser || chrome;
 	// Settings object with default settings
 	let settings = {
 		switchRegion: true,
+		keepAlive: false,
 		proxyCustom: false,
 		proxyHost: '',
 		proxyPort: 1080,
@@ -43,8 +44,11 @@ var browser = browser || chrome;
 				changed[key] = keys[key];
 			}
 		}
+		console.log('Settings changed:', changed);
 		browser.runtime.sendMessage({ event: 'settingsChanged', changed: changed, settings: settings });
+		console.log('Settings saved')
 		browser.storage.local.set({ settings: settings });
+		browser.runtime.sendMessage({ event: 'sets', changed: changed, settings: settings });
 	}
 
 	/**

--- a/src/settings.js
+++ b/src/settings.js
@@ -44,11 +44,8 @@ var browser = browser || chrome;
 				changed[key] = keys[key];
 			}
 		}
-		console.log('Settings changed:', changed);
 		browser.runtime.sendMessage({ event: 'settingsChanged', changed: changed, settings: settings });
-		console.log('Settings saved')
 		browser.storage.local.set({ settings: settings });
-		browser.runtime.sendMessage({ event: 'sets', changed: changed, settings: settings });
 	}
 
 	/**


### PR DESCRIPTION
This PR enhances proxy stability and performance through the following changes:

* **Keep-Alive Functionality:**
  Implements a keep-alive mechanism to maintain the proxy connection and prevent disconnection from providers like `webshare.io`, which may terminate idle connections. This helps avoid issues such as frozen video playback on Crunchyroll.

* **Optimized Proxy Test:**
  Updates the proxy test method from `GET` to `HEAD`, reducing unnecessary data transfer while still validating the connection effectively.

* **Permission Update:**
  Adds the `tabs` permission in the manifest. This is required to detect active Crunchyroll tabs and ensures the keep-alive connection is only maintained when needed.

These changes improve the reliability of the proxy service while minimizing bandwidth usage and maintaining user privacy.

